### PR TITLE
Delete null bytes at earlyer stage

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -288,6 +288,7 @@ impl<T: SetType> Session<T> {
             let mut result = NormalListResult::default();
             for line in &self.output {
                 for s in line.split("\n") {
+                    let s = s.trim_end_matches('\0');
                     if !s.is_empty() {
                         result.update_from_str(s)?;
                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -251,14 +251,22 @@ impl<T: SetType> Session<T> {
         if unset {
             self.unset_option(EnvOption::ListSetName);
         }
-        match ret? {
-            ListResult::Normal(_) => {
+        // Reset session data after list to avoid interfering with subsequent operations
+        unsafe {
+            binding::ipset_data_reset(self.data);
+        }
+        match ret {
+            Ok(ListResult::Normal(_)) => {
                 unreachable!("normal should not return")
             }
-            ListResult::Terse(names) => {
+            Ok(ListResult::Terse(names)) => {
                 let name = self.name.to_string_lossy().to_string();
                 Ok(names.contains(&name))
             }
+            Err(Error::Cmd(msg, true)) if msg.contains("does not exist") => {
+                Ok(false)
+            }
+            Err(e) => Err(e),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -877,7 +877,7 @@ impl<T: SetType> NormalListResult<T> {
                             options.push(AddOption::Packets(fields[i + 1].parse()?));
                         }
                         "bytes" => {
-                            options.push(AddOption::Bytes(fields[i + 1].parse()?));
+                            options.push(AddOption::Bytes(fields[i + 1].trim().replace("\0", "").parse()?));
                         }
                         "comment" => {
                             options.push(AddOption::Comment(fields[i + 1].to_string()));
@@ -925,10 +925,12 @@ impl<T: SetType> NormalListResult<T> {
 pub struct ListHeader {
     ipv6: bool,
     hash_size: u32,
+    bucket_size: Option<u32>,
     max_elem: u32,
     counters: bool,
     comment: bool,
     skbinfo: bool,
+    initval: Option<u32>
 }
 
 impl ListHeader {
@@ -946,6 +948,10 @@ impl ListHeader {
                     header.hash_size = s[i + 1].parse().unwrap();
                     i += 2;
                 }
+                "bucketsize" => {
+                    header.bucket_size = Some(s[i + 1].parse().unwrap());
+                    i += 2;
+                },
                 "maxelem" => {
                     header.max_elem = s[i + 1].parse().unwrap();
                     i += 2;
@@ -962,6 +968,13 @@ impl ListHeader {
                     header.skbinfo = true;
                     i += 1;
                 }
+                "initval" => {
+                    if let Some(initval) = s[i + 1].strip_prefix("0x") {
+                        header.initval = Some(u32::from_str_radix(initval, 16).unwrap());
+                    }
+                    i += 2;
+                }
+
                 _ => {
                     unreachable!("{} not supported", s[i]);
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -392,6 +392,14 @@ impl_name!(PortDataType, "port");
 impl_name!(IfaceDataType, "iface");
 impl_name!(MarkDataType, "mark");
 impl_name!(SetDataType, "set");
+
+// Special case for single-element tuple
+impl<A: TypeName> TypeName for (A,) {
+    fn name() -> String {
+        A::name()
+    }
+}
+
 impl_name!(A, B);
 impl_name!(A, B, C);
 
@@ -408,6 +416,13 @@ macro_rules! impl_set_data {
             }
         }
     };
+}
+
+// Special case for single-element tuple
+impl<T: SetType, A: SetData<T>> SetData<T> for (A,) {
+    fn set_data(&self, session: &Session<T>, from: Option<bool>) -> Result<(), Error> {
+        self.0.set_data(session, from)
+    }
 }
 
 impl_set_data!(A, B);
@@ -432,6 +447,13 @@ macro_rules! impl_parse {
             }
         }
     };
+}
+
+// Special case for single-element tuple
+impl<A: Parse> Parse for (A,) {
+    fn parse(&mut self, s: &str) -> Result<(), Error> {
+        self.0.parse(s)
+    }
 }
 
 impl_parse!(A, B);
@@ -880,7 +902,25 @@ impl<T: SetType> NormalListResult<T> {
                             options.push(AddOption::Bytes(fields[i + 1].parse()?));
                         }
                         "comment" => {
-                            options.push(AddOption::Comment(fields[i + 1].to_string()));
+                            // Collect all tokens between quotes
+                            let mut comment = String::new();
+                            let mut j = i + 1;
+                            while j < fields.len() {
+                                if !comment.is_empty() {
+                                    comment.push(' ');
+                                }
+                                comment.push_str(fields[j]);
+                                // Check if this token ends with a quote
+                                if fields[j].ends_with('"') {
+                                    break;
+                                }
+                                j += 1;
+                            }
+                            // Remove quotes
+                            comment = comment.trim_matches('"').to_string();
+                            options.push(AddOption::Comment(comment));
+                            i = j + 1; // Move past the last token of comment
+                            continue;
                         }
                         "skbmark" => {
                             let values: Vec<_> = fields[i + 1].split('/').collect();
@@ -927,6 +967,7 @@ pub struct ListHeader {
     hash_size: u32,
     bucket_size: Option<u32>,
     max_elem: u32,
+    timeout: Option<u32>,
     counters: bool,
     comment: bool,
     skbinfo: bool,
@@ -954,6 +995,10 @@ impl ListHeader {
                 },
                 "maxelem" => {
                     header.max_elem = s[i + 1].parse().unwrap();
+                    i += 2;
+                }
+                "timeout" => {
+                    header.timeout = Some(s[i + 1].parse().unwrap());
                     i += 2;
                 }
                 "counters" => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -877,7 +877,7 @@ impl<T: SetType> NormalListResult<T> {
                             options.push(AddOption::Packets(fields[i + 1].parse()?));
                         }
                         "bytes" => {
-                            options.push(AddOption::Bytes(fields[i + 1].trim().replace("\0", "").parse()?));
+                            options.push(AddOption::Bytes(fields[i + 1].parse()?));
                         }
                         "comment" => {
                             options.push(AddOption::Comment(fields[i + 1].to_string()));


### PR DESCRIPTION
Seems previous commit did not helps for all cases.
The new one, work fine for me

The problem short:
When code tried to list ipset with 100+ entries it uses some kind of pagination, and at the end of each "page" adds null byte that totally brakes the system